### PR TITLE
Fix setup-device.sh to work with unset LD_LIBRARY_PATH

### DIFF
--- a/setup-device.sh
+++ b/setup-device.sh
@@ -30,13 +30,13 @@ if ! grep -q ".NET Core SDK tools" "/home/pi/.bashrc"; then
 export PATH=${PATH}:/home/pi/.dotnet
 export PATH=${PATH}:/home/pi/.dotnet/tools
 export DOTNET_ROOT=/home/pi/.dotnet
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH-}:/usr/local/lib
 EOF
 fi
 export PATH=${PATH}:/home/pi/.dotnet
 export PATH=${PATH}:/home/pi/.dotnet/tools
 export DOTNET_ROOT=/home/pi/.dotnet
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH-}:/usr/local/lib
 echo ""
 
 

--- a/setup-device.sh
+++ b/setup-device.sh
@@ -30,13 +30,13 @@ if ! grep -q ".NET Core SDK tools" "/home/pi/.bashrc"; then
 export PATH=${PATH}:/home/pi/.dotnet
 export PATH=${PATH}:/home/pi/.dotnet/tools
 export DOTNET_ROOT=/home/pi/.dotnet
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH-}:/usr/local/lib
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}:/usr/local/lib
 EOF
 fi
 export PATH=${PATH}:/home/pi/.dotnet
 export PATH=${PATH}:/home/pi/.dotnet/tools
 export DOTNET_ROOT=/home/pi/.dotnet
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH-}:/usr/local/lib
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}:/usr/local/lib
 echo ""
 
 


### PR DESCRIPTION
I ran the setup-device.sh script, as per the README, to install this on my pi-top. The script bailed after this output:
```
Updating PATH, DOTNET_ROOT and LD_LIBRARY_PATH environment variables...
bash: line 39: LD_LIBRARY_PATH: unbound variable
```

I don't think it's unusual to have $LD_LIBRARY_PATH unset (unlike $PATH used next to it), so I've updated the script to use an empty string default for it.