### PR TITLE
Migrate from AppVeyor to GitHub action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,8 @@ name: Publish to NuGet
 on:
   push:
     branches:
-      - master # Default release branch
+      # - master # Default release branch
+      - feature/appveyorToGithubAction # Testing
 jobs:
   publish:
     name: Build, Pack & Publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,37 +22,37 @@ jobs:
         run: dotnet build --configuration Release --no-restore src/pi-top.sln
 
       - name: Publish PiTop.MakerArchitecture.Expansion.nuget
-        id: publish_nuget
         uses: brandedoutcast/publish-nuget@v2
         with:
           PROJECT_FILE_PATH: src/PiTop.MakerArchitecture.Expansion.nuget/PiTop.MakerArchitecture.Expansion.nuget.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
 
       - name: Publish PiTop.MakerArchitecture.Foundation.nuget
-        id: publish_nuget
         uses: brandedoutcast/publish-nuget@v2
         with:
           PROJECT_FILE_PATH: src/PiTop.MakerArchitecture.Foundation.nuget/PiTop.MakerArchitecture.Foundation.nuget.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
 
       - name: Publish PiTop.MakerArchitecture.Foundation.Psi.nuget
-        id: publish_nuget
         uses: brandedoutcast/publish-nuget@v2
         with:
           PROJECT_FILE_PATH: src/PiTop.MakerArchitecture.Foundation.Psi.nuget/PiTop.MakerArchitecture.Foundation.Psi.nuget.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
 
       - name: Publish PiTop.nuget
-        id: publish_nuget
         uses: brandedoutcast/publish-nuget@v2
         with:
           PROJECT_FILE_PATH: src/PiTop.nuget/PiTop.nuget.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
 
       - name: Publish PiTop.Camera.Psi.nuget
-        id: publish_nuget
         uses: brandedoutcast/publish-nuget@v2
         with:
           PROJECT_FILE_PATH: src/PiTop.Camera.Psi.nuget/PiTop.Camera.Psi.nuget.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
 
       - name: Publish PiTop.Camera.nuget
-        id: publish_nuget
         uses: brandedoutcast/publish-nuget@v2
         with:
           PROJECT_FILE_PATH: src/PiTop.Camera.nuget/PiTop.Camera.nuget.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,51 @@
+name: Publish to NuGet
+on:
+  push:
+    branches:
+      - master # Default release branch
+jobs:
+  publish:
+    name: Build, Pack & Publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      # - name: Setup dotnet
+      #   uses: actions/setup-dotnet@v1
+      #   with:
+      #     dotnet-version: 3.1.200
+
+      # Publish
+      - name: publish on version change
+        id: publish_nuget
+        uses: rohith/publish-nuget@v2
+        with:
+          # Filepath of the project to be packaged, relative to root of repository
+          PROJECT_FILE_PATH: Core/Core.csproj
+          
+          # NuGet package id, used for version detection & defaults to project name
+          # PACKAGE_NAME: Core
+          
+          # Filepath with version info, relative to root of repository & defaults to PROJECT_FILE_PATH
+          # VERSION_FILE_PATH: Directory.Build.props
+
+          # Regex pattern to extract version info in a capturing group
+          # VERSION_REGEX: ^\s*<Version>(.*)<\/Version>\s*$
+          
+          # Useful with external providers like Nerdbank.GitVersioning, ignores VERSION_FILE_PATH & VERSION_REGEX
+          # VERSION_STATIC: 1.0.0
+
+          # Flag to toggle git tagging, enabled by default
+          # TAG_COMMIT: true
+
+          # Format of the git tag, [*] gets replaced with actual version
+          # TAG_FORMAT: v*
+
+          # API key to authenticate with NuGet server
+          # NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+
+          # NuGet server uri hosting the packages, defaults to https://api.nuget.org
+          # NUGET_SOURCE: https://api.nuget.org
+
+          # Flag to toggle pushing symbols along with nuget package to the server, disabled by default
+          # INCLUDE_SYMBOLS: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,49 +5,54 @@ on:
       # - master # Default release branch
       - feature/appveyorToGithubAction # Testing
 jobs:
-  publish:
-    name: Build, Pack & Publish
+  build-test-pack-and-publish:
+    name: Build, Test, Pack & Publish
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      # - name: Setup dotnet
-      #   uses: actions/setup-dotnet@v1
-      #   with:
-      #     dotnet-version: 3.1.200
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v1
 
-      # Publish
-      - name: Publish on version change
+      - name: Install dependencies
+        run: dotnet restore src/pi-top.sln --verbosity q
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore src/pi-top.sln
+
+      - name: Publish PiTop.MakerArchitecture.Expansion.nuget
         id: publish_nuget
-        uses: rohith/publish-nuget@v2
+        uses: brandedoutcast/publish-nuget@v2
         with:
-          # Filepath of the project to be packaged, relative to root of repository
-          PROJECT_FILE_PATH: src/pi-top.sln
-          
-          # NuGet package id, used for version detection & defaults to project name
-          # PACKAGE_NAME: Core
-          
-          # Filepath with version info, relative to root of repository & defaults to PROJECT_FILE_PATH
-          # VERSION_FILE_PATH: Directory.Build.props
+          PROJECT_FILE_PATH: src/PiTop.MakerArchitecture.Expansion.nuget/PiTop.MakerArchitecture.Expansion.nuget.csproj
 
-          # Regex pattern to extract version info in a capturing group
-          # VERSION_REGEX: ^\s*<Version>(.*)<\/Version>\s*$
-          
-          # Useful with external providers like Nerdbank.GitVersioning, ignores VERSION_FILE_PATH & VERSION_REGEX
-          # VERSION_STATIC: 1.0.0
+      - name: Publish PiTop.MakerArchitecture.Foundation.nuget
+        id: publish_nuget
+        uses: brandedoutcast/publish-nuget@v2
+        with:
+          PROJECT_FILE_PATH: src/PiTop.MakerArchitecture.Foundation.nuget/PiTop.MakerArchitecture.Foundation.nuget.csproj
 
-          # Flag to toggle git tagging, enabled by default
-          # TAG_COMMIT: true
+      - name: Publish PiTop.MakerArchitecture.Foundation.Psi.nuget
+        id: publish_nuget
+        uses: brandedoutcast/publish-nuget@v2
+        with:
+          PROJECT_FILE_PATH: src/PiTop.MakerArchitecture.Foundation.Psi.nuget/PiTop.MakerArchitecture.Foundation.Psi.nuget.csproj
 
-          # Format of the git tag, [*] gets replaced with actual version
-          # TAG_FORMAT: v*
+      - name: Publish PiTop.nuget
+        id: publish_nuget
+        uses: brandedoutcast/publish-nuget@v2
+        with:
+          PROJECT_FILE_PATH: src/PiTop.nuget/PiTop.nuget.csproj
 
-          # API key to authenticate with NuGet server
-          # NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+      - name: Publish PiTop.Camera.Psi.nuget
+        id: publish_nuget
+        uses: brandedoutcast/publish-nuget@v2
+        with:
+          PROJECT_FILE_PATH: src/PiTop.Camera.Psi.nuget/PiTop.Camera.Psi.nuget.csproj
 
-          # NuGet server uri hosting the packages, defaults to https://api.nuget.org
-          # NUGET_SOURCE: https://api.nuget.org
-
-          # Flag to toggle pushing symbols along with nuget package to the server, disabled by default
-          # INCLUDE_SYMBOLS: false
+      - name: Publish PiTop.Camera.nuget
+        id: publish_nuget
+        uses: brandedoutcast/publish-nuget@v2
+        with:
+          PROJECT_FILE_PATH: src/PiTop.Camera.nuget/PiTop.Camera.nuget.csproj

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,8 @@ jobs:
     name: Build, Pack & Publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v2
 
       # - name: Setup dotnet
       #   uses: actions/setup-dotnet@v1
@@ -17,12 +18,12 @@ jobs:
       #     dotnet-version: 3.1.200
 
       # Publish
-      - name: publish on version change
+      - name: Publish on version change
         id: publish_nuget
         uses: rohith/publish-nuget@v2
         with:
           # Filepath of the project to be packaged, relative to root of repository
-          PROJECT_FILE_PATH: Core/Core.csproj
+          PROJECT_FILE_PATH: src/pi-top.sln
           
           # NuGet package id, used for version detection & defaults to project name
           # PACKAGE_NAME: Core

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,15 +23,15 @@ build_script:
   - cmd: dotnet build src/pi-top.sln
 after_build:
   # For once the build has completed
-  - cmd: dotnet pack src/PiTop.MakerArchitecture.Expansion.nuget/PiTop.MakerArchitecture.Expansion.nuget.csproj -o pacakges
-  - cmd: dotnet pack src/PiTop.MakerArchitecture.Foundation.nuget/PiTop.MakerArchitecture.Foundation.nuget.csproj -o pacakges
-  - cmd: dotnet pack src/PiTop.MakerArchitecture.Foundation.Psi.nuget/PiTop.MakerArchitecture.Foundation.Psi.nuget.csproj -o pacakges
-  - cmd: dotnet pack src/PiTop.nuget/PiTop.nuget.csproj -o pacakges
-  - cmd: dotnet pack src/PiTop.Camera.Psi.nuget/PiTop.Camera.Psi.nuget.csproj -o pacakges
-  - cmd: dotnet pack src/PiTop.Camera.nuget/PiTop.Camera.nuget.csproj -o pacakges
+  - cmd: dotnet pack src/PiTop.MakerArchitecture.Expansion.nuget/PiTop.MakerArchitecture.Expansion.nuget.csproj -o packages
+  - cmd: dotnet pack src/PiTop.MakerArchitecture.Foundation.nuget/PiTop.MakerArchitecture.Foundation.nuget.csproj -o packages
+  - cmd: dotnet pack src/PiTop.MakerArchitecture.Foundation.Psi.nuget/PiTop.MakerArchitecture.Foundation.Psi.nuget.csproj -o packages
+  - cmd: dotnet pack src/PiTop.nuget/PiTop.nuget.csproj -o packages
+  - cmd: dotnet pack src/PiTop.Camera.Psi.nuget/PiTop.Camera.Psi.nuget.csproj -o packages
+  - cmd: dotnet pack src/PiTop.Camera.nuget/PiTop.Camera.nuget.csproj -o packages
 artifacts:
-  - path: "pacakges/**/*.nupkg"
-    name: NugetPacakges
+  - path: "packages/**/*.nupkg"
+    name: NugetPackages
 
 clone_depth: 1
 test_script:


### PR DESCRIPTION
Useful link:
https://alessio.franceschelli.me/posts/dotnet/build-a-dotnet-library-with-github-actions/

Closes #28 

Still to do:
- [ ] Patch version before building
    - Current: [AppVeyor patch](https://github.com/pi-top/pi-top-4-.NET-SDK/blob/847286a7ef7c3e07a4d2cb80e2699377e0a27804/appveyor.yml#L3-L10)
    - Option: [AutoSemVerLib](https://github.com/chestercodes/AutoSemVerLib) (fork to work as GitHub Action?)
    - Option: just add a custom patch step to use the GitHub Run Number on master builds?
- [ ] Update README badge

GitHub Action build badge markdown:
```
![Build status](https://github.com/pi-top/pi-top-4-.NET-SDK/workflows/Publish%20to%20NuGet/badge.svg)
```

AppVeyor patching output:
```
Patching .NET Core project files
Patching PackageVersion in src\PiTop.Camera.nuget\PiTop.Camera.nuget.csproj...OK
Patching PackageVersion in src\PiTop.Camera.Psi.nuget\PiTop.Camera.Psi.nuget.csproj...OK
Patching PackageVersion in src\PiTop.MakerArchitecture.Expansion.nuget\PiTop.MakerArchitecture.Expansion.nuget.csproj...OK
Patching PackageVersion in src\PiTop.MakerArchitecture.Foundation.nuget\PiTop.MakerArchitecture.Foundation.nuget.csproj...OK
Patching PackageVersion in src\PiTop.MakerArchitecture.Foundation.Psi.nuget\PiTop.MakerArchitecture.Foundation.Psi.nuget.csproj...OK
Patching PackageVersion in src\PiTop.nuget\PiTop.nuget.csproj...OK
```