### PR TITLE
Improve RoverRobot BlinkAllLights

### DIFF
--- a/src/Examples/PiTop.MakerArchitecture.Expansion.Rover/RoverRobot.cs
+++ b/src/Examples/PiTop.MakerArchitecture.Expansion.Rover/RoverRobot.cs
@@ -117,6 +117,7 @@ namespace PiTop.MakerArchitecture.Expansion.Rover
             Observable
                 .Interval(TimeSpan.FromSeconds(0.2))
                 .Take(blinkCount)
+                .Finally(() => { AllLightsOff(); })
                 .Subscribe(_ =>
             {
                 ToggleAllLights();

--- a/src/Examples/PiTop.MakerArchitecture.Expansion.Rover/RoverRobot.cs
+++ b/src/Examples/PiTop.MakerArchitecture.Expansion.Rover/RoverRobot.cs
@@ -112,7 +112,7 @@ namespace PiTop.MakerArchitecture.Expansion.Rover
             BackLeftLed.Off();
         }
 
-        public void BlinkAllLights(int blinkCount = 5)
+        public void BlinkAllLights(int blinkCount = 6)
         {
             Observable
                 .Interval(TimeSpan.FromSeconds(0.2))


### PR DESCRIPTION
Currently the rover BlinkAllLights function leaves the led state toggled (off if they were on before, and on if not).

I would expect the lights to always all be left off after doing a 'blink' operation, so that is what this PR does. I also increased the default `blinkCount` to give 3 'blinks' from either starting state.

Arguably, they should instead just be kept in their initial state. If we prefer that, we probably need to ensure the `blinkCount` param is always an even number.

...Actually, I think that is better, and blinkCount should really count full 'on and off' toggles. Going to open a new PR instead of this.