### PR TITLE
Improve RobotRover BlinkAllLights

### DIFF
--- a/src/Examples/PiTop.Interactive.Rover/RoverRobotSetup.cs
+++ b/src/Examples/PiTop.Interactive.Rover/RoverRobotSetup.cs
@@ -57,7 +57,6 @@ namespace PiTop.Interactive.Rover
 
             var resourceScanner = new ResourceScanner();
 
-            roverBody.AllLightsOn();
             roverBody.BlinkAllLights();
 
             await csharpKernel.SetVariableAsync(nameof(roverBody), roverBody);

--- a/src/Examples/PiTop.MakerArchitecture.Expansion.Rover/RoverRobot.cs
+++ b/src/Examples/PiTop.MakerArchitecture.Expansion.Rover/RoverRobot.cs
@@ -112,11 +112,11 @@ namespace PiTop.MakerArchitecture.Expansion.Rover
             BackLeftLed.Off();
         }
 
-        public void BlinkAllLights(int blinkCount = 5)
+        public void BlinkAllLights(int blinkCount = 3)
         {
             Observable
                 .Interval(TimeSpan.FromSeconds(0.2))
-                .Take(blinkCount)
+                .Take(blinkCount * 2)
                 .Subscribe(_ =>
             {
                 ToggleAllLights();


### PR DESCRIPTION
Currently the rover BlinkAllLights function leaves the led state toggled (off if they were on before, and on if not).

This fixes that, leaving the lights in the same state as they were initially. It also ensures we always do 'full' blinks - toggling the state twice. The meaning of the `blinkCount` param is changed to mean the number of 'full' blinks, which I think is what you would expect. There is a `ToggleAllLights` method if you want a single toggle.

I removed a call to `roverBody.AllLightsOn()` in RoverRobotSetup as it seemed to only be there to ensure the lights were off after blinking, which is no longer an issue.